### PR TITLE
Improve quick start docs and add bootstrap TODO

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,15 @@ coordinates commands, and keeps your development directory organized.
 ```bash
 git clone git@github.com:jazzydog-labs/loom.git
 cd loom
-python3 loom.py init
+pip install -r requirements.txt
+python3 loom.py init --dev-root ~/dev     # add --no-bootstrap to skip extra setup
 ```
+
+`loom init` clones all repositories listed in `config/repos.yaml` and then
+attempts to run the `foundry-bootstrap/bootstrap.sh` script.  The bootstrapper
+installs system wide tools (Homebrew, pyenv, etc.) which may not run in
+restricted environments.  If the bootstrap step fails you can re-run
+`bootstrap.sh` manually or disable it via `--no-bootstrap`.
 
 ## Basic Commands
 

--- a/todo.md
+++ b/todo.md
@@ -11,6 +11,12 @@
   - Allow declarative color selection
 - Move configuration settings from Python into files
 
+## Bootstrap
+- [ ] Make `foundry-bootstrap/bootstrap.sh` detect unsupported environments and
+      skip Homebrew/pyenv installation when running inside a minimal container.
+      This will allow `loom init` to succeed in CI or Docker without manual
+      intervention.
+
 ## Architecture Skeleton
 - [ ] Integrate new `cli` package with Typer commands
 - [ ] Wire `app.LoomController` into existing CLI


### PR DESCRIPTION
## Summary
- document installation and bootstrap options in README
- add TODO about skipping bootstrap steps in container

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ab67b06188323932c6a693c397d5b