### PR TITLE
feat: add workflow docs (staff-grade)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ python3 loom.py details   # show repository details
 python3 loom.py go <repo> # enter a repository
 ```
 
+See [docs/workflows.md](docs/workflows.md) for a walkthrough of the common
+day‑to‑day commands and how they fit together.
+
 ## Configuration
 
 - **repos.yaml** – registry of sibling repositories

--- a/docs/design-workflow-docs.md
+++ b/docs/design-workflow-docs.md
@@ -1,0 +1,14 @@
+# Document desired workflows
+
+## Rationale
+The project currently lacks a central description of how Loom is intended to be used day to day. Providing a short
+workflow overview will help newcomers understand the common commands and how they fit together.
+
+## Proposed Changes
+- Add a new `docs/workflows.md` file outlining the typical Loom workflow.
+- Link the new page from `README.md` so users can discover it quickly.
+
+## Alternatives Considered
+The documentation could live entirely in the README, but splitting it keeps the quick-start short while allowing
+deeper explanations elsewhere.
+

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,0 +1,57 @@
+# Loom Workflows
+
+This page collects the core workflows expected when using Loom to manage a
+collection of repositories. Each command is shown with a short description so
+you can skim and copy as needed.
+
+## 1. Initialising a new environment
+
+```bash
+python3 loom.py init --dev-root ~/dev    # clones repos and runs bootstrap
+```
+
+This sets up the directory structure under `~/dev/foundry/` and optionally
+executes the bootstrap script for system dependencies.
+
+## 2. Checking repository status
+
+```bash
+python3 loom.py status
+```
+
+Displays a condensed table showing each repository's current branch and whether
+it is ahead, behind, or has local changes.
+
+## 3. Synchronising repositories
+
+```bash
+python3 loom.py sync
+```
+
+Runs `git pull` in parallel across all clean repositories. Add `--push` to also
+push commits that are already ahead of the upstream remote when it is safe to do
+so.
+
+## 4. Navigating into a repository
+
+```bash
+python3 loom.py go <repo>
+```
+
+Prints the path to `<repo>` and additional context such as the current branch or
+any outstanding changes. When used in a shell function it can also `cd` you into
+the directory directly.
+
+## 5. Listing TODO items
+
+```bash
+python3 loom.py todos
+```
+
+Aggregates TODOs from `todo.md` files and from `#todo:` comments inside the
+source code. Results are grouped by file for quick triage.
+
+---
+
+These workflows cover the most common day‑to‑day actions. For full command
+options run `python3 loom.py --help`.

--- a/todo.md
+++ b/todo.md
@@ -2,7 +2,7 @@
 
 ## Workflow
 - [x] Create a json-based interface to get all todos in a directory, from ./todo.md, and comments with `#todo:` in all code, for a particular repo. this should go in src/infra/todo_manager.py
-- [ ] Document desired workflows
+- [x] Document desired workflows
 
 ## Refactoring
 - Extract a clean JSON interface


### PR DESCRIPTION
## Summary
- document the common Loom workflows in `docs/workflows.md`
- link workflows guide from `README.md`
- mark todo for documenting workflows as complete
- add short design rationale

## Design Rationale
See `docs/design-workflow-docs.md` for motivation and alternatives considered.

## Risks
- Documentation may drift as commands evolve.

## Testing
- `ruff check .` *(fails: F401 in src/controllers/__init__.py)*
- `mypy src` *(fails: several type errors)*
- `pytest -q` *(fails during collection: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686b08d81a188323b1de788fb9b8899e